### PR TITLE
Julia 1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "0.3.1"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 DocumentFunction = "5593b220-aad2-11e8-0680-d9fc7de3193b"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+JLD = "4138dd39-2aa7-5051-a626-17a0bb65d9c8"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,15 @@
+authors = ["Velimir (monty) Vesselinov", "Boian Alexandrov", "Vesselin Grantcharov", "Daniel O'Malley"]
+name = "SVR"
+uuid = "3c50dbde-abaf-11e8-211a-656f602baacb"
+version = "0.3.1"
+
+[deps]
+DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+DocumentFunction = "5593b220-aad2-11e8-0680-d9fc7de3193b"
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
-julia 0.6
+julia 1.0
 JLD
 DocumentFunction
+Libdl

--- a/src/SVR.jl
+++ b/src/SVR.jl
@@ -2,7 +2,9 @@ __precompile__()
 
 module SVR
 
+using Base
 using Libdl
+using DelimitedFiles
 
 import JLD
 import DocumentFunction
@@ -347,7 +349,7 @@ function readlibsvmfile(file::String)
 		y = d[:,1]
 	end
 	for i = 2:p
-		x[:,i-1] = map(j->(parse(split(d[j,i], ':')[2])), collect(1:o))
+		x[:,i-1] = map(j->(parse(Float64, split(d[j,i], ':')[2])), collect(1:o))
 	end
 	return x, y
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,21 +1,23 @@
 import SVR
+using Test
+using DelimitedFiles
 
 currentdir = pwd()
 cd(dirname(@__FILE__))
 
-@Base.Test.testset "SVR" begin
+@testset "SVR" begin
 	y_true = vec(readdlm("mg.result"))
 
 	x, y = SVR.readlibsvmfile("mg.libsvm")
 
-	pmodel = SVR.train(y, x');
-	y_pr = SVR.predict(pmodel, x');
-	@Base.Test.test isapprox(maximum(abs.(y_pr .- y_true)), 0, atol=1e-4)
+	pmodel = SVR.train(y, copy(x'));
+	y_pr = SVR.predict(pmodel, copy(x'));
+	@test isapprox(maximum(abs.(y_pr .- y_true)), 0, atol=1e-4)
 	SVR.savemodel(pmodel, "mg.model")
 	SVR.freemodel(pmodel)
 
 	pmodel = SVR.loadmodel("mg.model")
-	y_pr = SVR.predict(pmodel, x');
+	y_pr = SVR.predict(pmodel, copy(x'));
 	# @assert maximum(abs.(y_pr .- y_true)) < 1e-4
 	SVR.freemodel(pmodel)
 end


### PR DESCRIPTION
Fixed language incompatibilities:
- struct declaration replaces by mutable struct  because of pointer_from_objref requirement
- liboutput should be defined before @cfunction macros call
- transpose operations like x' replaced by copy(x'). Julia 1.0 ::transpose returns LinearAlgebra.Adjoint type which should be instantiated in some specific type.

JLD for now is used from https://github.com/rssdev10/JLD.jl/tree/julia-1.0 branch. JLD's uuid at Project.toml might be changed after publishing of final JLD lib.